### PR TITLE
Changed template for INSERT statement to use " instead of '

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,7 @@ def parse_file_into_db(relative_file_path, type, db)
     name = item.content
     path = "#{parent_directory}/#{item.attr('href')}"
     insert_statement = <<-SQL
-      INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('#{name}', '#{type}', '#{path}');
+      INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ("#{name}", "#{type}", "#{path}");
     SQL
 
     db.execute insert_statement

--- a/Rakefile
+++ b/Rakefile
@@ -119,11 +119,11 @@ def parse_file_into_db(relative_file_path, type, db)
   document = Nokogiri::HTML(file)
   file.close
 
-  parent_directory = "/#{relative_file_path.split("/")[0..-2].join("/")}"
+  parent_directory = "#{relative_file_path.split("/")[0..-2].join("/")}"
 
   document.css('#sidebar ul.nav li a').each do |item|
     name = item.content
-    path = "#{parent_directory}/#{item.attr('href')}"
+    path = "#{parent_directory}/#{item.attr('href')}"[1..-1]
     insert_statement = <<-SQL
       INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ("#{name}", "#{type}", "#{path}");
     SQL

--- a/dist/docset.json
+++ b/dist/docset.json
@@ -1,6 +1,6 @@
 {
     "name": "PouchDB",
-    "version": "3.2.0",
+    "version": "5.2.0",
     "archive": "PouchDB.tgz",
     "author": {
         "name": "Buck Doyle",


### PR DESCRIPTION
In the previous implementation the single quote was used inside the SQL INSERT statement. This lead to an SQL error for the page "Who's using PouchDB?".
